### PR TITLE
Add 'Similar Libraries' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Some React issues that might simplify this once solved:
 - https://github.com/facebook/react/issues/140
 - https://github.com/facebook/react/issues/4751
 
+## Similar Libraries
+
+For mixing Polymer and React, there is [Maple](https://github.com/Wildhoney/Maple.js), which doesn't seem to be maintained anymore. However, if all you are looking for is a way to incorporate pre-built Material Design components into React, there are also [Material-UI](https://github.com/callemall/material-ui) and [React-Materialize](https://github.com/react-materialize/react-materialize). 
+
 ## License
 
 MIT.


### PR DESCRIPTION
Start a comparison with other projects that allow for incorporating MD components into React. There are a lot of people using the Material UI library, but are unhappy with its performance. Maybe they should consider using this library and bringing in Polymer components.
