### PR TITLE
Allow component to be used outside React context

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ var ReactPolymerPlugin = {
       targetInst,
       nativeEvent,
       nativeEventTarget) {
-    var targetNode = targetInst && ReactDOMComponentTree.getNodeFromInstance(targetInst)
+    if (!targetInst) {
+      return null
+    }
+    
+    var targetNode = ReactDOMComponentTree.getNodeFromInstance(targetInst)
 
     if (!customTopLevelTypes.hasOwnProperty(topLevelType) ||
         !isPolymerElement(targetNode)) {


### PR DESCRIPTION
We are using a custom Polymer element both inside React and outside React. Our element has a custom event which is registered so we can use that event in our React component. The root of our app is Polymer, and at a certain point React is used.

However, when we now try to use the same component outside of a React component, there is a null reference error. The reason for this is that in `extractEvents` the `targetInst` will be null (because there is no React Dom element). The following `isPolymerElement` will fail because it doesn't check whether the element is null.
